### PR TITLE
xCAT provision Sles11.2 will hang-on when excuting remoteshell script

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -281,9 +281,14 @@ if [ -f /etc/ssh/ssh_host_ecdsa_key ]; then
 	if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_ecdsa_key > /dev/null 2>&1 ; then
    		rm /etc/ssh/ssh_host_ecdsa_key
 	else
-		ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub
-		chmod 644 /etc/ssh/ssh_host_ecdsa_key.pub
-		chown root /etc/ssh/ssh_host_ecdsa_key.pub
+		ssh-keygen -t ecdsa -y -f /etc/ssh/ssh_host_ecdsa_key -P ""
+		if [ "x$?" = "x0" ]; then
+			ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub
+			chmod 644 /etc/ssh/ssh_host_ecdsa_key.pub
+			chown root /etc/ssh/ssh_host_ecdsa_key.pub
+		else
+			rm -fr /etc/ssh/ssh_host_ecdsa_key
+		fi
 	fi
   else
 	#This is an error message


### PR DESCRIPTION
xCAT provision Sles11.2 will hang-on and wait for input passphrase when executing "ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub" command in remoteshell script.

Root Cause: Sles11.2 install openssh-5.1p1-41.57.1 build-in package, and this version openssh don't support ecdsa key type.
So there needs a openssh support check before ecdsa key generation. In remoteshell script, line 283, we will add "ssh-keygen -t ecdsa -y -f /etc/ssh/ssh_host_ecdsa_key -P "" " command and check the result to judge support or not.
